### PR TITLE
Fix notifications

### DIFF
--- a/app/ducks/sc.js
+++ b/app/ducks/sc.js
@@ -77,7 +77,7 @@ export const connectSC = store => {
   });
   sc.notifications$().take(1).subscribe(action => {
     const n = action.payload.notification;
-    if (n.priority === 'alert') {
+    if (action.payload.priority === 'alert') {
       Alert.alert(n.title, n.body);
     }
   });


### PR DESCRIPTION
## Status
**READY**

## Description
Notification priority is on the payload, not notification object=

* 

@boundlessgeo/spatial-connect

