### PR TITLE
Add addRasterLayers method to bridge

### DIFF
--- a/app/ducks/map.js
+++ b/app/ducks/map.js
@@ -1,3 +1,4 @@
+import { NativeModules } from 'react-native';
 import { Actions } from 'react-native-router-flux';
 import { findIndex } from 'lodash';
 import * as sc from 'spatialconnect/native';
@@ -165,6 +166,7 @@ export const queryStores = (bbox = [-180, -90, 180, 90], limit = 50) =>
     dispatch({
       type: 'CLEAR_FEATURES',
     });
+    NativeModules.SCBridge.addRasterLayers(state.map.activeStores);
     sc.geospatialQuery$(filter, state.map.activeStores)
       .bufferWithTime(1000)
       .take(5)

--- a/ios/SCMobile/SCBridge.h
+++ b/ios/SCMobile/SCBridge.h
@@ -8,11 +8,13 @@
 
 #import <Foundation/Foundation.h>
 #import "RCTBridgeModule.h"
+#import "AIRMap.h"
 #import <SpatialConnect/SpatialConnect.h>
 #import <SpatialConnect/SCRCTBridge.h>
 
 @interface SCBridge : NSObject <RCTBridgeModule> {
   SCRCTBridge *scBridge;
+  AIRMap *mapView;
 }
 
 @end


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description
- This is a proposed method to check for and add new raster layers to the map.
- This could be called alongside `sc.geospatialQuery$` to query for vectors and rasters.
- `NativeModules.SCBridge.addRasterLayers` would be moved to spatialconnect-js
- Fixes new raster stores being added after map initialization (SPACON-410)
- Adds the ability to toggle raster layers on/off 

## Todos
- [ ] Tests
- [ ] Documentation

## Deploy Notes
Notes regarding deployment the contained body of work. 

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* 

@boundlessgeo/spatial-connect
