### PR TITLE
rename query to match spatialconnect-js api

### DIFF
--- a/app/ducks/map.js
+++ b/app/ducks/map.js
@@ -167,7 +167,7 @@ export const queryStores = (bbox = [-180, -90, 180, 90], limit = 50) =>
       type: 'CLEAR_FEATURES',
     });
     sc.addRasterLayers(state.map.activeStores);
-    sc.geospatialQuery$(filter, state.map.activeStores)
+    sc.spatialQuery$(filter, state.map.activeStores)
       .bufferWithTime(1000)
       .take(5)
       .map(actions => actions.map(a => a.payload))


### PR DESCRIPTION
## Status
**READY**

## Description
Renaming query to match [spatialconnect-js api changes](https://github.com/boundlessgeo/spatialconnect-js/pull/59)
