### PR TITLE
bindMapView callback + header button style fix

### DIFF
--- a/app/components/FeatureData.js
+++ b/app/components/FeatureData.js
@@ -1,23 +1,23 @@
 import React, { Component, PropTypes } from 'react';
 import {
-  Button,
+  Text,
+  TouchableHighlight,
   InteractionManager,
   ScrollView,
 } from 'react-native';
 import { find } from 'lodash';
 import Property from './Property';
-import { propertyListStyles } from '../style/style';
+import { propertyListStyles, routerStyles } from '../style/style';
 
 class FeatureData extends Component {
   static navigationOptions = {
     header: (nav, defaultHeader) => {
       return nav.state.params.editable ? ({
         ...defaultHeader,
-        right: (<Button
-          color={'white'}
-          title={'Edit'}
-          onPress={() => nav.navigate('editFeature', { feature: nav.state.params.feature })}
-        />),
+        right: (<TouchableHighlight
+          onPress={() => nav.navigate('editFeature', { feature: nav.state.params.feature })} >
+          <Text style={routerStyles.buttonTextStyle}>Edit</Text>
+        </TouchableHighlight>),
       }) : defaultHeader;
     },
   }

--- a/app/components/FeatureEdit.js
+++ b/app/components/FeatureEdit.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import {
-  Button,
+  TouchableHighlight,
   InteractionManager,
   ScrollView,
   StyleSheet,
@@ -20,6 +20,7 @@ import turfPoint from 'turf-point';
 import * as mapActions from '../ducks/map';
 import * as mapUtils from '../utils/map';
 import palette from '../style/palette';
+import { routerStyles } from '../style/style';
 
 const Form = t.form.Form;
 
@@ -85,11 +86,10 @@ class FeatureEdit extends Component {
       return nav.state.params.onRight ? ({
         ...defaultHeader,
         title: 'Edit Feature',
-        right: (<Button
-          color={'white'}
-          title={'Save'}
-          onPress={nav.state.params.onRight}
-        />),
+        right: (<TouchableHighlight
+          onPress={nav.state.params.onRight}>
+          <Text style={routerStyles.buttonTextStyle}>Save</Text>
+        </TouchableHighlight>),
       }) : defaultHeader;
     },
   }

--- a/app/components/SCMap.js
+++ b/app/components/SCMap.js
@@ -104,8 +104,11 @@ class SCMap extends Component {
   componentDidMount() {
     InteractionManager.runAfterInteractions(() => {
       this.setState({ renderPlaceholderOnly: false }, () => {
-        sc.addRasterLayers(this.props.activeStores);
-        sc.bindMapView(findNodeHandle(this.scMap));
+        sc.bindMapView(findNodeHandle(this.scMap), (error) => {
+          if (!error) {
+            sc.addRasterLayers(this.props.activeStores);
+          }
+        });
       });
       this.regionChangeComplete$ = new Rx.Subject();
       this.regionChangeComplete$

--- a/app/style/style.js
+++ b/app/style/style.js
@@ -153,6 +153,8 @@ export const routerStyles = StyleSheet.create({
   },
   buttonTextStyle: {
     color: 'white',
+    fontWeight: 'bold',
+    paddingRight: 10,
   },
   icon: {
     tintColor: 'green',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-native-image-picker": "^0.22.9",
     "react-native-maps": "file:../react-native-maps",
     "react-native-slider": "^0.8.0",
-    "react-native-spatialconnect": "0.9.1",
+    "react-native-spatialconnect": "0.9.2",
     "react-native-vector-icons": "4.0.0",
     "react-navigation": "react-community/react-navigation",
     "react-redux": "4.4.5",


### PR DESCRIPTION
## Status
**READY**

## Description
- Fixes bug that could occur when trying to add/remove overlays from the native mapView before `bindMapView` had been called
- Header buttons were not appearing correctly on Android, changed to be simple white text components

## Todos
- [x] Tests
- [x] Documentation

* 

@boundlessgeo/spatial-connect
