### PR TITLE
Added release vars to build.gradle file

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -17,4 +17,11 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
+# Below information is need to sign the release version of the apk
+# More information can be found https://developer.android.com/studio/publish/app-signing.html
+SC_RELEASE_STORE_FILE=need to create your own
+SC_RELEASE_KEY_ALIAS=need to create your own
+SC_RELEASE_STORE_PASSWORD=need to create your own
+SC_RELEASE_KEY_PASSWORD=need to create your own
+
 android.useDeprecatedNdk=true


### PR DESCRIPTION
## Status
**READY**

## Description
Added release build vars in gradle to ensure code builds in runs in debug mode after cloning the repo

## Todos
- [ ] Tests
- [ ] Documentation

## Steps to Test or Reproduce
Download repo and run android without adding to the gradle.properties file

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* 

@boundlessgeo/spatial-connect
