### PR TITLE
Fixing deps around android tools upgrade, adding back enableGPS

### DIFF
--- a/app/ducks/sc.js
+++ b/app/ducks/sc.js
@@ -69,6 +69,6 @@ export const connectSC = (store) => {
       console.warn(err);
     }
   } else {
-    //sc.enableGPS();
+    sc.enableGPS();
   }
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-native": "0.44.0",
     "react-native-button": "1.7.1",
     "react-native-drawer": "^2.2.3",
-    "react-native-image-picker": "^0.22.9",
+    "react-native-image-picker": "^0.26.3",
     "react-native-maps": "boundlessgeo/react-native-maps",
     "react-native-slider": "^0.8.0",
     "react-native-spatialconnect": "0.11.2",


### PR DESCRIPTION
## Status
**READY**

## Description
Added back enabledGPS and upgraded `react-native-image-picker` to support the new android tools upgrade.

## Todos
- [ ] Tests
- [ ] Documentation

## Deploy Notes
Notes regarding deployment the contained body of work. 

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* 

@boundlessgeo/spatial-connect
