### PR TITLE
Scroll to focused form field

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "rx": "^4.1.0",
     "should": "9.0.2",
     "slash": "^1.0.0",
-    "spatialconnect-form-schema": "2.3.2",
+    "spatialconnect-form-schema": "2.3.4",
     "tcomb-form-native": "^0.5.1",
     "tcomb-json-schema": "^0.3.0",
     "turf-bbox": "3.0.12",


### PR DESCRIPTION
## Status
**READY**

## Jira
UMC-1

## Description
- Add `onFocus` to each form field to automatically scroll to it when selected
- Fix keyboard overlaying form fields by adding bottom padding when keyboard is shown

## Todos
- [x] Tests JS
- [x] Test iOS
- [x] Test Android
